### PR TITLE
fix: case sensitive email comparison

### DIFF
--- a/src/integrations/emailmarketing/Flexmail.php
+++ b/src/integrations/emailmarketing/Flexmail.php
@@ -366,7 +366,7 @@ class Flexmail extends EmailMarketing
         $contacts = $this->getPaginated('contacts', ['query'=>['email'=>$email]]);
 
         foreach ($contacts as $contact) {
-            if ($contact['email'] == $email) {
+            if (isset($contact['email']) && strcasecmp(trim($contact['email']), trim($email)) === 0) {
                 return $contact;
             }
         }


### PR DESCRIPTION
Closes #4

Fix was suggested by copilot. I would have went with `strtolower`, but this seems more appropriate.